### PR TITLE
Reorder solution status checking

### DIFF
--- a/src/cpp_cbc_solve.cpp
+++ b/src/cpp_cbc_solve.cpp
@@ -83,10 +83,10 @@ List cpp_cbc_solve(NumericVector obj,
   bool isAbandoned = model.isAbandoned();
   if (isOptimal) {
     status = "optimal";
-  } else if (isInfeasible) {
-    status = "infeasible";
   } else if (isUnbounded) {
     status = "unbounded";
+  } else if (isInfeasible) {
+    status = "infeasible";
   } else if (isNodeLimitedReached) {
     status = "nodelimit";
   } else if (isSolutionLimitReached) {


### PR DESCRIPTION
Dual infeasible solution should take precedence in the status code to primal infeasibility. Fix issue #9