### PR TITLE
Fix Windows installation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,7 @@ Authors@R: c(
 License: GPL-3 + file LICENSE
 NeedsCompilation: yes
 SystemRequirements: CBC libraries and headers
+Biarch: true
 Encoding: UTF-8
 LazyData: true
 LinkingTo: Rcpp

--- a/configure.win
+++ b/configure.win
@@ -1,0 +1,2 @@
+# No configuration needed on Windows
+# (this suppresses an unnecessary warning message during installation)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,9 @@
+VERSION = 4.9.3
+RWINLIB = ../windows/cbc-2.9.8/lib-$(VERSION)$(R_ARCH)
+
 PKG_CPPFLAGS = -I../windows/cbc-2.9.8/include/coin
-PKG_LIBS = -L../windows/cbc-2.9.8/lib${subst gcc,,${COMPILED_BY}}${R_ARCH} \
+
+PKG_LIBS = -L$(RWINLIB) \
 	-lCbcSolver -lClpSolver \
 	-lOsiCbc -lCbc -lCgl -lOsiClp -lClp -lOsi -lCoinUtils -lz -lm
 


### PR DESCRIPTION
This PR fixes enables successful installation on Windows platforms (tested both locally and with GitHub Actions CI). As such, it should fix #4 and #34.The specific changes and their rationale are as follows:

1. The `Makevars.win` file was updated to include the specific version of CBC available on RWinLib (i.e. 4.9.3). This update is based on a similar `Makevars.win` file for the sf package (see https://github.com/r-spatial/sf/blob/master/src/Makevars.win).
2. Since installing an R package from source without a `configure.win` fdile on a Windows system will print a message that could be confused with an error message (even though the installation is successful), this PR also include a dummy `configure.win` file to suppress the error message. For a similar example of this, see the rgl package (https://github.com/dmurdoch/rgl/blob/master/configure.win).
3. To ensure successful installation for both i385 and x64 plaforms on Windows when a `configure.win` file is present, I have added `Biarch: true` to the DESCRIPTION (see https://github.com/dmurdoch/rgl/issues/19). This is mainly relevant for ensuring that any packages that (might in the future?) depend on rcbc can easily use GitHub Action workflows for continuous integration. 

To test this branch on your own computer, you should be able to use the following code:

```
if (!require(remotes)) install.packages("remotes")
remotes::install_github("jeffreyhanson/rcbc@win2")
```