### PR TITLE
update cbc rwinlib version

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,7 +1,7 @@
-VERSION = 4.9.3
-RWINLIB = ../windows/cbc-2.9.8/lib-$(VERSION)$(R_ARCH)
+VERSION = 2.10.5
+RWINLIB = ../windows/cbc-$(VERSION)/lib$(R_ARCH)
 
-PKG_CPPFLAGS = -I../windows/cbc-2.9.8/include/coin
+PKG_CPPFLAGS = -I../windows/cbc-$(VERSION)/include/coin
 
 PKG_LIBS = -L$(RWINLIB) \
 	-lCbcSolver -lClpSolver \

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -2,9 +2,9 @@ if(getRversion() < "3.3.0") {
   stop("R version too old. On Windows this package requires at least R-3.3")
 }
 
-# Download cbc-2.9.8 from rwinlib
-if(!file.exists("../windows/cbc-2.9.8/include/coin/CbcSolver.hpp")){
-  download.file("https://github.com/rwinlib/cbc/archive/v2.9.8.zip", "lib.zip", quiet = TRUE)
+# Download cbc-2.10.5 from rwinlib
+if(!file.exists("../windows/cbc-2.10.5/include/coin/CbcSolver.hpp")){
+  download.file("https://github.com/rwinlib/cbc/archive/v2.10.5.zip", "lib.zip", quiet = TRUE)
   dir.create("../windows", showWarnings = FALSE)
   unzip("lib.zip", exdir = "../windows")
   unlink("lib.zip")

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -4,7 +4,9 @@ if(getRversion() < "3.3.0") {
 
 # Download cbc-2.10.5 from rwinlib
 if(!file.exists("../windows/cbc-2.10.5/include/coin/CbcSolver.hpp")){
-  download.file("https://github.com/rwinlib/cbc/archive/v2.10.5.zip", "lib.zip", quiet = TRUE)
+  download.file(
+    "https://github.com/rwinlib/cbc/archive/v2.10.5.zip", "lib.zip",
+    quiet = TRUE)
   dir.create("../windows", showWarnings = FALSE)
   unzip("lib.zip", exdir = "../windows")
   unlink("lib.zip")


### PR DESCRIPTION
This PR updates the rcbc package to use the [latest version of CBC available on rwinlib (i.e. 2.10.5) for Windows installation](https://github.com/rwinlib/cbc/releases).