### PR TITLE
Fix memory issues with large problems (#63)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,5 +33,5 @@ Suggests:
     testthat,
     knitr,
     rmarkdown
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 VignetteBuilder: knitr

--- a/R/as_Matrix.R
+++ b/R/as_Matrix.R
@@ -1,0 +1,60 @@
+#' Convert to Matrix
+#'
+#' Convert an object to a matrix class provided by the \pkg{Matrix} package.
+#'
+#' @param object object.
+#'
+#' @param class `character` name of new classes.
+#'
+#' @details
+#' This function is a wrapper that is designed to provide
+#' compatibility with older and newer versions of the \pkg{Matrix} package.
+#'
+#' @return `Matrix` object.
+#'
+#' @noRd
+as_Matrix <- function(object, class) {
+  # assert valid argument
+  assertthat::assert_that(
+    assertthat::is.string(class),
+    assertthat::noNA(class)
+  )
+  # if we just want to convert to generic Matrix class then do that...
+  if (identical(class, "Matrix")) {
+    return(methods::as(object, class))
+  }
+  # convert matrix
+  # nocov start
+  if (utils::packageVersion("Matrix") >= as.package_version("1.4-2")) {
+    if (identical(class, "dgCMatrix")) {
+      c1 <- "dMatrix"
+      c2 <- "generalMatrix"
+      c3 <- "CsparseMatrix"
+    } else if (identical(class, "dgTMatrix")) {
+      c1 <- "dMatrix"
+      c2 <- "generalMatrix"
+      c3 <- "TsparseMatrix"
+    } else if (identical(class, "dsCMatrix")) {
+      c1 <- "dMatrix"
+      c2 <- "symmetricMatrix"
+      c3 <- "CsparseMatrix"
+    } else if (identical(class, "dsTMatrix")) {
+      c1 <- "dMatrix"
+      c2 <- "symmetricMatrix"
+      c3 <- "TsparseMatrix"
+    } else if (identical(class, "lgCMatrix")) {
+      c1 <- "lMatrix"
+      c2 <- "generalMatrix"
+      c3 <- "CsparseMatrix"
+    } else {
+      stop("argument to \"class\" not recognized")
+    }
+    out <- methods::as(methods::as(methods::as(object, c1), c2), c3)
+  } else {
+    out <- methods::as(object, class)
+  }
+  # nocov end
+  # return result
+  out
+}
+

--- a/R/cbc_solve.R
+++ b/R/cbc_solve.R
@@ -283,7 +283,7 @@ cbc_solve <- function(obj,
   )
   ## coerce mat to sparse matrix
   if (!inherits(mat, "dgTMatrix")) {
-    mat <- as(mat, "dgTMatrix")
+    mat <- as_Matrix(mat, "dgTMatrix")
   }
   ## check for missing values
   assert_that(
@@ -292,7 +292,11 @@ cbc_solve <- function(obj,
   )
   assert_that(noNA(mat@x), msg = "argument to mat contains missing values")
   # finite values
-  assert_that(all(is.finite(obj)), all(is.finite(mat)))
+  assert_that(
+    all(is.finite(mat@x)),
+    msg = "argument to mat contains missing values"
+  )
+  assert_that(all(is.finite(obj)))
   ## dimensionality
   assert_that(
     length(obj) == ncol(mat),

--- a/tests/testthat/test-cbc-solver.R
+++ b/tests/testthat/test-cbc-solver.R
@@ -2,7 +2,7 @@ context("cbc_solve")
 
 describe("cbc_solve", {
   it("solves a simple MIP", {
-    A <- as(matrix(c(1, 2, 3, 4), ncol = 2, nrow = 2), "dgTMatrix")
+    A <- as_Matrix(matrix(c(1, 2, 3, 4), ncol = 2, nrow = 2), "dgTMatrix")
     result <- cbc_solve(
               obj = c(1, 2),
               mat = A,
@@ -123,7 +123,7 @@ describe("cbc_solve", {
     expect_equal(2, objective_value(result))
   })
   it("can handle an initial solution", {
-    A <- as(matrix(c(1, 2, 3, 4), ncol = 2, nrow = 2), "dgTMatrix")
+    A <- as_Matrix(matrix(c(1, 2, 3, 4), ncol = 2, nrow = 2), "dgTMatrix")
     result <- cbc_solve(
               obj = c(1, 2),
               is_integer = c(TRUE, TRUE),


### PR DESCRIPTION
This PR fixes the memory issues raised in #63. Specifically, there are data checks in the current version that accidently convert a sparse matrix to a regular matrix and, in turn, massively increase the memory required to solve problems. I think this mistake might have been part of a previous PR that I made - sorry about that!

I have also taken this opportunity to update the package to be compatible with upcomming changes to the Matrix package (i.e. upcomming version 1.4.2, please see below for email from Matrix package maintainer with more information). In the upcomming version, many `as(x, MATRIX_CLASS)` methods will be deprecated. Since `as(x, "dgTMatrix")` will be deprecated, users should instead use `as(as(as(x, "dMatrix"), "generalMatrix"), "TsparseMatrix")` to acheive the same result. Similarly, instead of `as(x, "dgCMatrix")`, users should use `as(as(as(x, "dMatrix"), "generalMatrix"), "CsparseMatrix")`. As such, I've added a new `as_Matrix()` internal function to handle the conversions correctly for the current Matrix version and the upcomming Martix version. 

What do you think? Please let me know if you have any questions, or if there's anything else I can do to the PR to help get this merged?

<details>
<summary>Expand to see email from Matrix maintainers regarding upcomming Matrix package </summary>

Dear R Maintainer maintainer,

You are receiving this message because at least one CRAN or
Bioconductor package that you maintain requires revisions due to
deprecations in the forthcoming Matrix version 1.4-2, which you can
install with

> install.packages("Matrix", repos = "http://r-forge.r-project.org/")

(The list of 259 affected packages with 209 unique maintainers
 is at the end)

Matrix 1.4-2 will formally deprecate 187 coercion methods.  More
precisely, coercions of the form

> as(object, Class)

where

* 'object' inherits from the virtual class Matrix, is a traditional
  matrix, or is a logical or numeric vector

* 'Class' specifies a non-virtual subclass of Matrix, such as
  dgCMatrix, but really any subclass matching the pattern

      ^[dln]([gts][CRT]|di|ge|tr|sy|tp|sp)Matrix$

will continue to work as before but signal a deprecation message or
warning (_message_ in the widely used dg.Matrix and d.CMatrix cases).

By default, the message or warning will be signaled with the first
deprecated method call and suppressed after that.  Signaling can be
controlled via option Matrix.warnDeprecatedCoerce:

<=0 = be completely silent  [[ at your own risk ! ]]
  1 = warn each time
>=2 = error each time  [[ for debugging ]]
 NA = message or warn once then be silent  [[ the default ]]

Deprecated coercions in your package sources (including examples,
tests, and vignettes) should be revised to go via virtual classes
_only_, as has been advocated for quite some time in

> vignette("Design-issues", package = "Matrix")

For example, rather than

> as(<matrix>, "dgCMatrix")

we recommend (the full, a "permutation", or a simplification given the
context of)

> as(as(as(<matrix>, "dMatrix"), "generalMatrix"), "CsparseMatrix")

To simplify the revision process, the development version of Matrix
provides Matrix:::.as.via.virtual(), taking a pair of class names and
returning as a call the correct nesting of coercions:

> Matrix:::.as.via.virtual("matrix", "dgCMatrix")
as(as(as(from, "dMatrix"), "generalMatrix"), "CsparseMatrix")
> Matrix:::.as.via.virtual("matrix", "lsTMatrix")
as(as(as(from, "lMatrix"), "symmetricMatrix"), "TsparseMatrix")
> Matrix:::.as.via.virtual("dgCMatrix", "dtrMatrix")
as(as(from, "triangularMatrix"), "unpackedMatrix")

We suggest checking package tarballs built with

> options(Matrix.warnDeprecatedCoerce = n) # where n >= 1

in the .onLoad() hook (see ?.onLoad), so that all deprecated coercions
are exposed in the check output.  (If you find that a warning or error
has been signaled from 'Matrix' itself, then we'd welcome a report
containing a minimal reproducible example, so that we may revise our
own code.)

If you are unable to make the requested changes before Sep 8 (~4 weeks
from now), or if you need help or clarification while fixing your code,
please let us know by replying and copying

Thank you very much!

</details>