### PR TITLE
fix bug in initial_solution not working

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rcbc
 Type: Package
 Title: COIN CBC MILP Solver Bindings
-Version: 0.1.0.9002
+Version: 0.1.0.9003
 Description: An R interface to the CBC solver for mixed-integer linear programs.
 Authors@R: c(
   person("Dirk", "Schumacher",

--- a/src/cpp_cbc_solve.cpp
+++ b/src/cpp_cbc_solve.cpp
@@ -64,18 +64,14 @@ SEXP rcbc_cpp_cbc_solve(SEXP obj,
   CbcMain0(model);
 
   // if initial solution specified, then add it to the model
-  /// declare variable to specify initial solution
-  std::vector< std::pair<std::string,double> > initialSolution_data;
   if (Rf_asLogical(useInitialSolution)) {
-    /// pre-allocate memory for variable
-    initialSolution_data.reserve(n);
+    /// declare variable to specify initial solution
+    std::vector< std::pair<std::string,double> > initialSolution_data(n);
     /// append pairs to store initial solution information
     for (R_len_t i = 0; i < n; ++i) {
-      initialSolution_data.push_back(
-        std::pair<std::string,double>(
-          std::string(CHAR(STRING_ELT(initialNames, i))),
-          REAL(initialSolution)[i]
-        )
+      initialSolution_data[i] = std::pair<std::string,double>(
+        std::string(CHAR(STRING_ELT(initialNames, i))),
+        REAL(initialSolution)[i]
       );
     }
     /// specify initial values

--- a/src/cpp_cbc_solve.cpp
+++ b/src/cpp_cbc_solve.cpp
@@ -47,15 +47,9 @@ SEXP rcbc_cpp_cbc_solve(SEXP obj,
     solver.setObjSense(-1);
   }
 
-  // create model
-  CbcModel model(solver);
-  CbcMain0(model);
-
-  // set initial solution if specified
-  /// declare variable to specify initial solution
-  std::vector< std::pair<std::string,double> > initialSolution_data;
+  // if initial solution specified, then set column names
+  const int n = Rf_length(initialIndex);
   if (Rf_asLogical(useInitialSolution)) {
-    const int n = Rf_length(initialIndex);
     /// set variable names
     for (R_len_t i = 0; i < n; ++i) {
       solver.setColName(
@@ -63,7 +57,16 @@ SEXP rcbc_cpp_cbc_solve(SEXP obj,
         CHAR(STRING_ELT(initialNames, i))
       );
     }
+  }
 
+  // create model
+  CbcModel model(solver);
+  CbcMain0(model);
+
+  // if initial solution specified, then add it to the model
+  /// declare variable to specify initial solution
+  std::vector< std::pair<std::string,double> > initialSolution_data;
+  if (Rf_asLogical(useInitialSolution)) {
     /// pre-allocate memory for variable
     initialSolution_data.reserve(n);
     /// append pairs to store initial solution information

--- a/tests/testthat/test-cbc-solver.R
+++ b/tests/testthat/test-cbc-solver.R
@@ -137,7 +137,22 @@ describe("cbc_solve", {
     expect_equal(c(1, 0), column_solution(result))
     expect_equal("optimal", solution_status(result))
   })
-
+  it("returns optimal initial solution", {
+    A <- as_Matrix(matrix(c(1, 1, 1, 1), ncol = 2, nrow = 2), "dgTMatrix")
+    result <-
+     cbc_solve(
+              obj = c(1, 1),
+              is_integer = c(TRUE, TRUE),
+              mat = A,
+              row_lb = c(1, 1),
+              row_ub = c(1, 1),
+              max = TRUE,
+              cbc_args = list("logLevel" = 0),
+              initial_solution = c(1, 0))
+    expect_equal(1, objective_value(result))
+    expect_equal(c(1, 0), column_solution(result))
+    expect_equal("optimal", solution_status(result))
+  })
 })
 
 describe("prepare_cbc_args", {


### PR DESCRIPTION
This PR aims to fix a bug where an argument supplied to `initial_solution` is not actually being used in the optimization process (#72).